### PR TITLE
Little Tweaks and Documentation Idea

### DIFF
--- a/potential-documentation/latex-utils.scrbl
+++ b/potential-documentation/latex-utils.scrbl
@@ -1,0 +1,113 @@
+#lang scribble/manual
+
+@(require pollen pollen/decode pollen/misc/tutorial
+          txexpr sugar hyphenate
+          scribble/example
+          latex-utils/scribble)
+
+@title[#:date "October, 2016"]{LaTeX Utils for Scribble and Pollen}
+
+@author{M. Eyzaguirre and K. L. Smith}
+
+@section{General Math Tools}
+
+@subsection{Math Modes}
+
+@defproc[(m [body (listof? value?)]) content?]{
+ Produces LaTeX inline maths. More specifically, parses @racket[body] into valid LaTeX markup and wraps it in @tt{\(...\)}.
+}
+
+@defproc[(mp [body (listof? value)]) content?]{
+ Like @racket[(m body)], but produces display math instead. After @racket[body] is parsed into valid markup, it is wrapped in @tt{\[...\]}.
+}
+
+
+@subsection{Fonts}
+
+@defform[(cal body)]{
+ Applies the LaTeX bold math font @tt{\matcal} to @racket[body].
+}
+
+@defform[(mcal body)]{
+ Equivalent to @racket[(m (cal body))].
+}
+
+
+@defform[(bb body)]{
+ Applies the LaTeX bold math font @tt{\mathbb} to @racket[body].
+}
+
+@defform[(mbb body)]{
+ Equivalent to @racket[(m (bb body))].
+}
+
+
+@defform[(bf body)]{
+ Applies the LaTeX bold math font @tt{\mathbf} to @racket[body].
+}
+
+@defform[(mbf body)]{
+ Equivalent to @racket[(m (bf body))].
+}
+
+
+@defform[(sf body)]{
+ Applies the LaTeX bold math font @tt{\mathsf} to @racket[body].
+}
+
+@defform[(msf body)]{
+ Equivalent to @racket[(m (sf body))].
+}
+
+
+@defform[(rm body)]{
+ Applies the LaTeX bold math font @tt{\mathrm} to @racket[body].
+}
+
+@defform[(mrm body)]{
+ Equivalent to @racket[(m (rm body))].
+}
+
+
+@subsection{Delimiters}
+
+@defform[(delim delims-expr body)
+         #:grammar ([delims-expr (code:line)
+                     delims-string
+                     delims-list]
+                    [delims-string (code:line)
+                     "()"
+                     "[]"
+                     "{}"
+                     "<>"
+                     "||"]
+                    [delims-list (code:line)
+                     (list "\\langle" "\\rangle")
+                     (list "\\lvert" "\\rvert")
+                     (list "\\lVert" "\\rVert")])]{
+ Wraps @racket[body] in the math delimiters specified by @racket[delims-expr].
+}
+
+@defform[(parens body)]{
+ Equivalent to @racket[(delim "()" body)].
+}
+
+
+@subsection{Math Structures and Objects}
+
+@defform[(od var body)]{
+ Produces a Leibniz @emph{ordinary} derivative expression of @racket[body] with respect to @racket[var].
+}
+
+@defform[(pd var body)]{
+ Produces a Leibniz @emph{partial} derivative expression of @racket[body] with respect to @racket[var].
+}
+
+
+@defform[(one body)]{
+ Produces a fraction that is equal to one (@emph{i.e.,} @racket[body]/@racket[body]).
+}
+
+
+
+@section{Scribble Theorem Tools}

--- a/scribble/math.rkt
+++ b/scribble/math.rkt
@@ -4,7 +4,8 @@
          align* envalign* style-matrix matrix
          sub
          cal mcal bb mbb bf mbf sf msf rm mrm
-         dd delim paren implies one
+         delim parens
+         od pd implies one
          forall exists)
 
 (require "private/math.rkt"
@@ -16,9 +17,12 @@
          racket/match
          racket/sequence)
 
+
+; ↓↓↓↓ math modes
+
 (define-syntax-rule (m items ...)
   (cond [(math-mode) (exact items ...)]
-        [else (in-math (exact "$" items ... "$"))]))
+        [else (in-math (exact "\\(" items ... "\\)"))]))
 
 (define-syntax-rule (mp items ...)
   (cond [(math-mode) (exact items ...)]
@@ -27,6 +31,9 @@
 (define-syntax-rule (um items ...)
   (cond [(math-mode) (unmath (exact "\\mbox{" items ... "}"))]
         [else (exact items ...)]))
+
+
+; ↓↓↓↓ something about arrays/matrices?
 
 (define-syntax (sep-rows stx)
   (syntax-case stx ()
@@ -89,6 +96,9 @@
         ""
         (list "_{" (value->content (car scripts)) (rec (cdr scripts)) "}"))))
 
+
+; ↓↓↓↓ math fonts
+
 (define (cal . stuff)
   (list "{\\mathcal{" stuff "}}"))
 
@@ -119,8 +129,8 @@
 (define (mrm . stuff)
   (m (rm stuff)))
 
-(define (dd var . stuff)
-  (list "{\\frac{d" stuff "}{d" var "}}"))
+
+; ↓↓↓↓ math delimiters
 
 (define (delim delims . stuff)
   (let ([delims (if (string? delims)
@@ -134,16 +144,28 @@
           "\\right"
           (value->content (sequence-ref delims 1) #:auto-wrap? #f #:escape? #t))))
 
-(define (paren . stuff)
+(define (parens . stuff)
   (delim "()" stuff))
 
-(define implies "\\Rightarrow")
+; add more syntactic sugar for common delimiters?
+
+
+; ↓↓↓↓ miscellaneous math objects
+
+(define implies "\\Rightarrow") ; redundant with LaTeX \implies
+
+(define (one . content)
+  (list "\\frac{" content "}{" content "}"))
+
+(define (od var . stuff) ; need to add handling for optional order
+  (list "{\\frac{\\mathrm{d}" stuff "}{\\mathrm{d}" var "}}"))
+
+(define (pd var . stuff) ; need to add handling for optional order
+  (list "{\\frac{\\partial" stuff "}{\\partial" var "}}"))
+
 
 (define (forall item (set #f) (delims #f) (relation "∈"))
   (quantifier "∀" item set delims relation))
 
 (define (exists item (set #f) (delims #f) (relation "∈"))
   (quantifier "∃" item set delims relation))
-
-(define (one . content)
-  (list "\\frac{" content "}{" content "}"))


### PR DESCRIPTION
`scribble/math.rkt` : Added sections to and reorganized slightly to group things. Fixed `m` wrapping math in '$...$' to '(...)'. Changed `paren` to `parens` (clarifies use). Replaced `dd` with `od` that includes accurate differential operators. Added `pd`, same as `od` but with partial differentials.

`potential-documentation` : Directory created.
`potential-documentation/latex-utils.scrbl` : Created. Just an example of how I see formatting things.
